### PR TITLE
#114 make links target the top frame (gh-pages)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
+
 <head>
     <meta charset="UTF-8">
     <title>Dynamo by opencirclesolutions</title>
@@ -9,38 +10,53 @@
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
 </head>
+
 <body>
-<section class="page-header">
-    <img src="logo.png" />
-    <h2 class="project-tagline">Web Application Accelerator Framework</h2>
-    <a href="https://github.com/opencirclesolutions/dynamo" class="btn">View on GitHub</a>
-    <a href="https://github.com/opencirclesolutions/dynamo/zipball/master" class="btn">Download .zip</a>
-    <a href="https://github.com/opencirclesolutions/dynamo/tarball/master" class="btn">Download .tar.gz</a>
-</section>
+    <section class="page-header">
+        <img src="logo.png" />
+        <h2 class="project-tagline">Web Application Accelerator Framework</h2>
+        <a href="https://github.com/opencirclesolutions/dynamo" class="btn" target="_top">View on GitHub</a>
+        <a href="https://github.com/opencirclesolutions/dynamo/zipball/master" class="btn" target="_top">Download .zip</a>
+        <a href="https://github.com/opencirclesolutions/dynamo/tarball/master" class="btn" target="_top">Download .tar.gz</a>
+    </section>
 
-<section class="main-content">
-    <p>The Dynamo Web Application Accelerator is a software development framework initially developed by Open Circle Solutions that aims to <b>increase productivity</b> by using design principles such as convention over configuration, model-driven development and DRY (Don't Repeat Yourself).</p>
+    <section class="main-content">
+        <p>The Dynamo Web Application Accelerator is a software development framework initially developed by Open Circle Solutions
+            that aims to
+            <b>increase productivity</b> by using design principles such as convention over configuration, model-driven development
+            and DRY (Don't Repeat Yourself).</p>
 
-    <p>At the core of Dynamo is the concept of the Entity Model. The Entity Model is defined as the model describes the attributes and behavior of an entity (or domain object) in your application. This entity model can then be used as the basis for creating forms, tables, search screens etc. </p>
+        <p>At the core of Dynamo is the concept of the Entity Model. The Entity Model is defined as the model describes the
+            attributes and behavior of an entity (or domain object) in your application. This entity model can then be used
+            as the basis for creating forms, tables, search screens etc. </p>
 
-    <p>The Entity Model of an entity can be automatically generated based on the properties of the attribute model (using sensible defaults as described by the <b>convention over configuration</b> principle) and can further be modified by using attributes and message bundle overwrites. The main goal is to reduce the amount of (boilerplate) code required to perform common actions like creating search screens and edit forms.</p>
+        <p>The Entity Model of an entity can be automatically generated based on the properties of the attribute model (using
+            sensible defaults as described by the
+            <b>convention over configuration</b> principle) and can further be modified by using attributes and message bundle
+            overwrites. The main goal is to reduce the amount of (boilerplate) code required to perform common actions like
+            creating search screens and edit forms.</p>
 
-    <p>Complementing the Entity Model is a set of user interface components (widgets) that can be used to <b>quickly construct screens</b> for common use cases, and a number of base classes for the Data Access and Service layers.
-        The  Framework is built around a number of proven and highly productive set of technologies:</p>
+        <p>Complementing the Entity Model is a set of user interface components (widgets) that can be used to
+            <b>quickly construct screens</b> for common use cases, and a number of base classes for the Data Access and Service
+            layers. The Framework is built around a number of proven and highly productive set of technologies:</p>
 
-    <ul>
-        <li>  Vaadin as the user interface framework</li>
-        <li>  Spring as the application framework</li>
-        <li>  JPA2 for ORM</li>
-        <li>  QueryDSL for type-safe query generation</li>
-        <li>  Apache Camel for integration</li>
-    </ul>
+        <ul>
+            <li> Vaadin as the user interface framework</li>
+            <li> Spring as the application framework</li>
+            <li> JPA2 for ORM</li>
+            <li> QueryDSL for type-safe query generation</li>
+            <li> Apache Camel for integration</li>
+        </ul>
 
-    <p>Interested in contributing? Check our <a href="https://github.com/opencirclesolutions/dynamo/wiki">wiki</a>!</p>
+        <p>Interested in contributing? Check our
+            <a href="https://github.com/opencirclesolutions/dynamo/wiki" target="_top">wiki</a>!</p>
 
-    <footer class="site-footer">
-        <span class="site-footer-owner"><a href="https://github.com/opencirclesolutions/dynamo">Dynamo</a> is maintained by <a href="http://www.opencirclesolutions.nl">Open Circle Solutions</a>.</span>
-    </footer>
-</section>
+        <footer class="site-footer">
+            <span class="site-footer-owner">
+                <a href="https://github.com/opencirclesolutions/dynamo" target="_top">Dynamo</a> is maintained by
+                <a href="http://www.opencirclesolutions.nl" target="_top">Open Circle Solutions</a>.</span>
+        </footer>
+    </section>
 </body>
+
 </html>


### PR DESCRIPTION
github pages uses iframe-magic that breaks http to https links, forcing these links and buttons to target the top-level frame (the html document) fixes this issue

result: links are now usable