### PR TITLE
Disable the 'Save' button when there are no editable fields.

### DIFF
--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.html
@@ -197,7 +197,7 @@
                         <button
                                 type="submit"
                                 class="btn btn-primary m-1"
-                                [disabled]="loading"
+                                [disabled]="loading || isFormDisabled()"
                                 (click)="save()">
                             <span class="pi pi-save"></span> {{ "save" | translate }}
                         </button>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.ts
@@ -469,6 +469,11 @@ export class GenericFormComponent
     return getErrorString(attribute, this.mainForm!, this.translate);
   }
 
+  isFormDisabled(): boolean {
+    // Edge case when there are no editable fields on the entity
+    return this.mainForm!.disabled;
+  }
+
   save(): void {
     if (this.confirmSave === true) {
       var callback = (event: any): void => {


### PR DESCRIPTION
Prevent the user from being able to use the 'Save' button if a generated form has no editable inputs.

This PR fixes or closes issue: fixes : fixes #288