### PR TITLE
Minor change in resolving the locale

### DIFF
--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/base-composite/base-composite.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/base-composite/base-composite.component.ts
@@ -51,6 +51,7 @@ import { PagingModel } from '../../../interfaces/model/pagingModel';
 import { SortModel } from '../../../interfaces/model/sortModel';
 import { AdditionalGlobalAction } from '../../../interfaces/action';
 import { EntityModelActionResponse } from '../../../interfaces/model/entityModelActionResponse';
+import {TranslateService} from "@ngx-translate/core";
 
 @Component({
   selector: 'd-base-composite',
@@ -87,7 +88,7 @@ export abstract class BaseCompositeComponent {
   // optional reference to further specify which entity model to use
   @Input() entityModelReference?: string = undefined;
   // the locale to use
-  @Input() public locale: string = getLocale();
+  @Input() public locale: string;
   // default filters to apply when searching
   @Input() defaultFilters: FilterModel[] = [];
   // filters to apply to individual fields
@@ -129,6 +130,10 @@ export abstract class BaseCompositeComponent {
 
     this.service = configuration.getCRUDService()
     this.entityModelService = configuration.getModelService()
+
+    // use the translation service to determine the active locale, only fallback to the getLocale when unknown
+    const translationService = inject(TranslateService)
+    this.locale = translationService.currentLang || translationService.defaultLang || getLocale()
   }
 
   lookupEntities(key: string): any[] {


### PR DESCRIPTION
The `BaseCompositeComponent` falls back to the 'en' locale when the locale is not set on the component using the `Input`. This can cause issues when no 'en' translations are present with missing labels in the UI.

The PR changes this to utilize the `TranslationService` to resolve the locale, only if no current locale and no default locale is set will dynamo fallback to 'en'.

This PR is related to #289 