### PR TITLE
Fix issue with the lookup-field not opening entity search dialog.

### DIFF
--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/data-table/data-table.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/data-table/data-table.component.ts
@@ -127,7 +127,7 @@ export class DataTableComponent implements OnInit {
       }
       this.selectedIds.push(event.id);
     } else {
-      this.selectedIds = this.selectedIds.slice(index + 1, index + 2);
+      this.selectedIds = this.selectedIds.filter((id) => id !== event.id);
     }
     if (this.detailsModeEnabled && !this.showDetailButton) {
       this.rowClick.emit(event);

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.html
@@ -3,7 +3,6 @@
     [(visible)]="dialogVisible"
     [style]="{ width: '70vw' }"
     [modal]="true">
-    <p>Dialog!</p>
     <d-generic-search-layout
         [entityName]="entityName"
         [entityModelReference]="entityModelReference"
@@ -11,6 +10,7 @@
         [selectedIds]="selectedIds"
         [multiSelect]="multiSelect"
         [nested]="true"
+        (onRowSelect)="entitySelected($event)"
         [searchImmediately]="true"
         [defaultFilters]="defaultFilters"
         [queryType]="queryType"></d-generic-search-layout>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
@@ -60,14 +60,14 @@ export class EntitySearchDialogComponent
   @Output() onChange = new EventEmitter<any>();
 
   entitySelected(event: any) {
-    const inCache = this.valueCache.find(element => element.value.id === event.id);
+    const inCache = this.valueCache.find(element => element.value === event.id);
     if (!inCache) {
       this.valueCache.push({
         name: this.displayPropertyName ? event[this.displayPropertyName] : '',
         value: event.id
       });
     } else {
-      this.valueCache = this.valueCache.filter(element => element.value.id !== event.id);
+      this.valueCache = this.valueCache.filter(element => element.value !== event.id);
     }
   }
 

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
@@ -60,6 +60,11 @@ export class EntitySearchDialogComponent
   @Output() onChange = new EventEmitter<any>();
 
   entitySelected(event: any) {
+    if (!this.multiSelect) {
+      // prevent multiple selected when that is not available
+      this.valueCache = [];
+    }
+
     const inCache = this.valueCache.find(element => element.value === event.id);
     if (!inCache) {
       this.valueCache.push({

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
@@ -54,9 +54,22 @@ export class EntitySearchDialogComponent
   selectedValues: SelectOption[] = [];
   // value cache, for holding the items selected in the popup
   valueCache: SelectOption[] = [];
+  displayPropertyName?: string;
 
   @Output() onRowSelect = new EventEmitter<any>();
   @Output() onChange = new EventEmitter<any>();
+
+  entitySelected(event: any) {
+    const inCache = this.valueCache.find(element => element.value.id === event.id);
+    if (!inCache) {
+      this.valueCache.push({
+        name: this.displayPropertyName ? event[this.displayPropertyName] : '',
+        value: event.id
+      });
+    } else {
+      this.valueCache = this.valueCache.filter(element => element.value.id !== event.id);
+    }
+  }
 
   protected onLookupFilled(am: AttributeModelResponse): void {
   }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
@@ -156,8 +156,7 @@ export class LookupFieldComponent
   }
 
   clear() {
-    this.selectedValues = [];
-    this.onChange(this.multiSelect ? this.selectedValues : this.selectedValues[0]);
+    this.writeValue(undefined);
   }
 
   getSelectedValueString() {

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
@@ -157,7 +157,7 @@ export class LookupFieldComponent
 
   clear() {
     this.selectedValues = [];
-    this.onChange(this.selectedValues);
+    this.onChange(this.multiSelect ? this.selectedValues : this.selectedValues[0]);
   }
 
   getSelectedValueString() {

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-import {Component, forwardRef, inject, Input, OnInit, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, forwardRef, inject, Input, ViewChild, ViewContainerRef} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {TranslateModule, TranslateService} from '@ngx-translate/core';
 import {EntityModelResponse} from '../../../../interfaces/model/entityModelResponse';
@@ -47,7 +47,7 @@ import {EntitySearchDialogComponent} from "../../../dialogs/entity-search-dialog
 })
 export class LookupFieldComponent
   extends BaseComponent
-  implements ControlValueAccessor, OnInit {
+  implements ControlValueAccessor {
   private authService = inject(AuthenticationService);
 
   // the name of the entity to display
@@ -101,12 +101,7 @@ export class LookupFieldComponent
     super(translate);
   }
 
-  ngOnInit(): void {
-  }
-
   showDialog(): void {
-    console.log("Trying to open dialog2!");
-
     this.valueCache = [];
     this.selectedValues.forEach((element) => this.valueCache.push(element));
     this.selectedIds = [];
@@ -116,14 +111,19 @@ export class LookupFieldComponent
 
     this.header = this.translate.instant('search_header', {title: ''});
 
-    // let componentRef = this.searchDialogRef.createComponent(EntitySearchDialogComponent);
-    // componentRef.instance.entityModelReference = this.entityModelReference;
-    // componentRef.instance.entityName = this.entityName;
-    // componentRef.instance.selectedIds = this.selectedIds;
-    // componentRef.instance.multiSelect = this.multiSelect;
-    // componentRef.instance.defaultFilters = this.defaultFilters;
-    // // // TODO: query type
-    // componentRef.instance.showDialog();
+    let componentRef = this.searchDialogRef.createComponent(EntitySearchDialogComponent);
+    componentRef.instance.entityName = this.entityName;
+    componentRef.instance.displayPropertyName = this.displayPropertyName;
+    componentRef.instance.selectedIds = this.selectedIds;
+    componentRef.instance.valueCache = this.valueCache;
+    componentRef.instance.selectedValues = this.selectedValues;
+    componentRef.instance.multiSelect = this.multiSelect;
+    componentRef.instance.defaultFilters = this.defaultFilters;
+    const subscription = componentRef.instance.onChange.subscribe(event => {
+      this.writeValue(event)
+      subscription.unsubscribe();
+    });
+    componentRef.instance.showDialog();
   }
 
   showQuickAddDialog() {
@@ -138,17 +138,6 @@ export class LookupFieldComponent
     componentRef.instance.showDialog();
   }
 
-  // showSearchDialog(): void {
-  //   let componentRef = this.searchDialogRef.createComponent(EntitySearchDialogComponent);
-  //   componentRef.instance.entityModelReference = this.entityModelReference;
-  //   componentRef.instance.entityName = this.entityName;
-  //   //componentRef.instance.readOnly = false;
-  //   // componentRef.instance.onDialogClosed = (obj: any): void => {
-  //   //   this.afterQuickAddDialogClosed(obj);
-  //   // };
-  //   componentRef.instance.showDialog();
-  // }
-
   afterQuickAddDialogClosed(obj: any) {
     if (!this.multiSelect) {
       this.selectedValues = [];
@@ -158,47 +147,12 @@ export class LookupFieldComponent
       value: obj.id,
       name: obj[this.displayPropertyName],
     });
+    this.selectedIds.push(obj.id);
+    this.onChange(this.selectedIds);
   }
 
   getHeader(): string {
     return this.header;
-  }
-
-  /**
-   * Closes the dialog and applies the selection
-   */
-  // selectAndClose(): void {
-  //   this.selectedValues = [];
-  //   this.valueCache.forEach((element) => this.selectedValues.push(element));
-  //   if (this.multiSelect) {
-  //     this.onChange(this.selectedValues);
-  //   } else {
-  //     this.onChange(this.selectedValues[0]);
-  //   }
-  //
-  //   //this.dialogVisible = false;
-  // }
-
-  /**
-   * Respond to selection of a row in the popup dialog
-   * @param event the row select event (contains the entire row object)
-   */
-  onRowSelect(event: any) {
-    if (this.multiSelect) {
-      let match = this.valueCache.find((val) => val.value === event.id);
-      if (!match) {
-        this.valueCache.push({
-          value: event.id,
-          name: event[this.displayPropertyName],
-        });
-      }
-    } else {
-      this.valueCache = [];
-      this.valueCache.push({
-        value: event.id,
-        name: event[this.displayPropertyName],
-      });
-    }
   }
 
   clear() {
@@ -224,6 +178,7 @@ export class LookupFieldComponent
     } else {
       this.selectedValues = [];
     }
+    this.onChange(this.multiSelect ? this.selectedValues : this.selectedValues[0]);
   }
 
   registerOnChange(onChange: any) {

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-entity-field/select-entity-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-entity-field/select-entity-field.component.ts
@@ -43,7 +43,7 @@ import {EntityPopupDialogComponent} from "../../../dialogs/entity-popup-dialog/e
 @Component({
   selector: 'd-select-entity-field',
   standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, MessageModule, DropdownModule, MultiSelectModule, AutoCompleteModule, TooltipModule, LookupFieldComponent, ReactiveFormsModule],
+  imports: [ReactiveFormsModule, CommonModule, MessageModule, DropdownModule, MultiSelectModule, AutoCompleteModule, TooltipModule, forwardRef(() => LookupFieldComponent), ReactiveFormsModule],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-many-field/select-many-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-many-field/select-many-field.component.ts
@@ -41,7 +41,7 @@ import {EntityPopupDialogComponent} from "../../../dialogs/entity-popup-dialog/e
       multi: true,
     },
   ],
-  imports: [MessageModule, TooltipModule, ReactiveFormsModule, MultiSelectModule, LookupFieldComponent, ReactiveFormsModule],
+  imports: [MessageModule, TooltipModule, ReactiveFormsModule, MultiSelectModule, forwardRef(() => LookupFieldComponent), ReactiveFormsModule],
   templateUrl: './select-many-field.component.html',
   styleUrl: './select-many-field.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/flexible-search-form/flexible-search-form.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/flexible-search-form/flexible-search-form.component.ts
@@ -63,8 +63,8 @@ export interface SearchRow {
 @Component({
   selector: 'd-flexible-search-form',
   standalone: true,
-  imports: [TranslateModule, CommonModule, ReactiveFormsModule, PanelModule, DropdownModule, TooltipModule, TriStateCheckboxModule, StringFieldComponent, SelectManyFieldComponent,
-    SelectEntityFieldComponent, EnumFieldComponent, TimeFieldComponent, DecimalFieldComponent, DateFieldComponent, TimestampFieldComponent, NumberFieldComponent, ElementCollectionFieldComponent],
+  imports: [TranslateModule, CommonModule, ReactiveFormsModule, PanelModule, DropdownModule, TooltipModule, TriStateCheckboxModule, StringFieldComponent, forwardRef(() => SelectManyFieldComponent),
+    forwardRef(() => SelectEntityFieldComponent), EnumFieldComponent, TimeFieldComponent, DecimalFieldComponent, DateFieldComponent, TimestampFieldComponent, NumberFieldComponent, ElementCollectionFieldComponent],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-form/generic-search-form.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-form/generic-search-form.component.ts
@@ -49,8 +49,8 @@ import { PanelModule } from 'primeng/panel';
 @Component({
   selector: 'd-generic-search-form',
   standalone: true,
-  imports: [TranslateModule, CommonModule, ReactiveFormsModule, PanelModule, TriStateCheckboxModule, TooltipModule, ElementCollectionFieldComponent, SelectManyFieldComponent,
-     SelectEntityFieldComponent, TimeFieldComponent, TimestampFieldComponent, DateFieldComponent, EnumFieldComponent, DecimalFieldComponent, NumberFieldComponent, StringFieldComponent],
+  imports: [TranslateModule, CommonModule, ReactiveFormsModule, PanelModule, TriStateCheckboxModule, TooltipModule, ElementCollectionFieldComponent, forwardRef(() => SelectManyFieldComponent),
+    forwardRef(() => SelectEntityFieldComponent), TimeFieldComponent, TimestampFieldComponent, DateFieldComponent, EnumFieldComponent, DecimalFieldComponent, NumberFieldComponent, StringFieldComponent],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-layout/generic-search-layout.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-layout/generic-search-layout.component.ts
@@ -32,12 +32,11 @@ import { FlexibleSearchFormComponent } from '../flexible-search-form/flexible-se
 import { BaseCompositeCollectionComponent } from '../../base-composite-collection/base-composite-collection.component';
 import { GenericSearchFormComponent } from '../generic-search-form/generic-search-form.component';
 import {NG_VALUE_ACCESSOR} from "@angular/forms";
-import {EntityPopupDialogComponent} from "../../../dialogs/entity-popup-dialog/entity-popup-dialog.component";
 
 @Component({
   selector: 'd-generic-search-layout',
   standalone: true,
-  imports: [TranslateModule, DividerModule, GenericTableComponent, FlexibleSearchFormComponent, GenericSearchFormComponent],
+  imports: [TranslateModule, DividerModule, GenericTableComponent, forwardRef(() => FlexibleSearchFormComponent), forwardRef(() => GenericSearchFormComponent)],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
### Suggested change

1. Add the logic to the `lookup-field` to open the `entity-search-dialog`. 
2. Fix the entity search component and the `lookup-field` and the `entity-search-dialog` to pass selected rows correctly into the form.
3. Resolve an issue with circular imports between the various components (`generic-search-layout` required `lookup-field` which uses `generic-search-layout` for the search dialog)

This PR closes #315.