### PR TITLE
Angular19 add workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,9 @@ indent_size = 4
 
 [*.css]
 indent_size = 2
+
+[create-release.yml]
+indent_size = 2
+
+[publish-release.yml]
+indent_size = 2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
   validate:
     # restrict access to this job to prevent accidental release triggers from non OCS authors
     if: contains('["gjong","klafbang", "pdeenen", "tommy-ocs", "wittekip"]', github.actor)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.determine_version.outputs.version }}
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
+          distribution: 'temurin'
           java-version: '21'
           architecture: x64
           cache: 'maven'
@@ -58,7 +58,7 @@ jobs:
   #  - `tagged`: the full version number that was used, including any postfix set like 'RC1'
   set-version:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tagged: ${{ steps.set_version.outputs.tag_version }}
     steps:
@@ -67,8 +67,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
-          java-version: '24'
+          distribution: 'temurin'
+          java-version: '21'
           architecture: x64
           cache: 'maven'
       - name: Configure Git
@@ -101,7 +101,7 @@ jobs:
   # The release will be created as 'Draft' to allow custom release notes to be added.
   github-release:
     needs: set-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ needs.set-version.outputs.tagged }}
     steps:
       - name: Create github release
@@ -122,15 +122,15 @@ jobs:
     needs:
       - validate
       - set-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
-          java-version: '24'
+          distribution: 'temurin'
+          java-version: '21'
           architecture: x64
           cache: 'maven'
       - name: Configure Git

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,154 @@
+name: Create Dynamo Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      desired_version:
+        description: 'The version to set when creating the release, e.g.: 1.1.0'
+        required: true
+      postfix:
+        description: 'Any postfix to be appended to the release, e.g.: RC1'
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+
+  # Validate job will check if the current version is actually a *-SNAPSHOT, if not, this flow cannot be used.
+  # Outputs:
+  #   `version`: the current version of the Dynamo
+  validate:
+    # restrict access to this job to prevent accidental release triggers from non OCS authors
+    if: contains('["gjong","klafbang", "pdeenen", "tommy-ocs", "wittekip"]', github.actor)
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.determine_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+          architecture: x64
+          cache: 'maven'
+      - name: Build software
+        run: mvn -B install --no-transfer-progress --file pom.xml
+      - name: Determine version
+        id: determine_version
+        run: |
+          current_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Current version: ${current_version}"
+          echo "version=${current_version}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${current_version}" >> $GITHUB_ENV
+      - name: Check if snapshot
+        run: |
+          echo "Project version is: ${{ env.CURRENT_VERSION }}"
+          if [[ "${{ env.CURRENT_VERSION }}" != *"-SNAPSHOT"* ]]; then
+            echo "::error::Release version should contain -SNAPSHOT"
+            exit 1
+          else
+            echo "Release version is correct (contains -SNAPSHOT)"
+          fi
+
+  # Set version will set the stable version number the same as the input variable `desired_version` of the workflow.
+  # Outputs:
+  #  - `tagged`: the full version number that was used, including any postfix set like 'RC1'
+  set-version:
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      tagged: ${{ steps.set_version.outputs.tag_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '24'
+          architecture: x64
+          cache: 'maven'
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "gjong@users.noreply.github.com"
+      - name: Set release version
+        id: set_version
+        run: |
+          RELEASE_VERSION="${{ github.event.inputs.desired_version }}"
+          if [ -n "${{ github.event.inputs.postfix }}" ]; then
+            echo "Appending postfix: ${{ github.event.inputs.postfix }}"
+            RELEASE_VERSION="${RELEASE_VERSION}-${{ github.event.inputs.postfix }}"
+          fi;
+          echo "Setting project version: ${RELEASE_VERSION}"
+          mvn versions:set versions:commit -DnewVersion="${RELEASE_VERSION}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          echo "tag_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+      - name: Commit release
+        run: |
+          git add .
+          git commit -m "chore: prepare release ${{ env.RELEASE_VERSION }}"
+          git push
+      - name: Tagging stable release
+        run: |
+          git tag ${{ env.RELEASE_VERSION }}
+          git push origin ${{ env.RELEASE_VERSION }}
+
+  # Create a release in Github with the same version as the Dynamo release.
+  # The release will be created as 'Draft' to allow custom release notes to be added.
+  github-release:
+    needs: set-version
+    runs-on: ubuntu-latest
+    if: ${{ needs.set-version.outputs.tagged }}
+    steps:
+      - name: Create github release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.set-version.outputs.tagged }}
+          name: Release ${{ needs.set-version.outputs.tagged }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Changes the version of Dynamo to the next desired *-SNAPSHOT version.
+  # If the postfix was set, then the version will be reverted to the one discovered in the `validate`-job,
+  # otherwise the Maven versions plugin is used to set the next snapshot version.
+  prepare-next:
+    needs:
+      - validate
+      - set-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '24'
+          architecture: x64
+          cache: 'maven'
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "gjong@users.noreply.github.com"
+          git pull
+      - name: Prepare next build phase
+        run: |
+          if [ -n "${{ github.event.inputs.postfix }}" ]; then
+            mvn versions:set versions:commit -DnewVersion="${{ needs.validate.outputs.version }}" -q
+          else
+            mvn versions:set versions:commit -DnextSnapshot -q
+          fi;
+          NEXT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
+      - name: Pushing committed snapshot
+        run: |
+          git add .
+          git commit -m "chore: prepare snapshot version ${{ env.NEXT_VERSION }}"
+          git push

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,35 @@
+name: Publish Dynamo release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '24'
+          architecture: x64
+          cache: 'maven'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase:  MAVEN_GPG_PASSPHRASE
+      - name: Deploy to registry
+        run: mvn -B clean deploy -P release
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,15 +10,15 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
-          java-version: '24'
+          distribution: 'temurin'
+          java-version: '21'
           architecture: x64
           cache: 'maven'
           server-id: central

--- a/dynamo-angular/pom.xml
+++ b/dynamo-angular/pom.xml
@@ -121,14 +121,67 @@
 					<stagingDirectory>../target/staging/maven</stagingDirectory>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>com.ragedunicorn.tools.maven</groupId>
-				<artifactId>github-release-maven-plugin</artifactId>
-				<version>1.0.7</version>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>release</id>
+			<properties>
+				<node.auth_token/>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.7.0</version>
+						<extensions>true</extensions>
+						<configuration>
+							<skipPublishing>true</skipPublishing>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>com.github.eirslett</groupId>
+						<artifactId>frontend-maven-plugin</artifactId>
+						<version>1.15.1</version>
+						<configuration>
+							<workingDirectory>src/main/dynamo/</workingDirectory>
+							<installDirectory>target</installDirectory>
+						</configuration>
+						<executions>
+							<execution>
+								<id>fixate-version</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<configuration>
+									<arguments>version --allow-same-version ${project.version}</arguments>
+									<workingDirectory>src/main/dynamo/dist/dynamo-angular</workingDirectory>
+								</configuration>
+								<phase>package</phase>
+							</execution>
+							<execution>
+								<id>publish</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<configuration>
+									<arguments>publish --access public</arguments>
+									<workingDirectory>src/main/dynamo/dist/dynamo-angular</workingDirectory>
+								</configuration>
+								<phase>deploy</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/dynamo-angular/src/main/dynamo/package-lock.json
+++ b/dynamo-angular/src/main/dynamo/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dynamo",
+  "name": "@open-circle-solutions/dynamo",
   "version": "4.0.0-RC3-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dynamo",
+      "name": "@open-circle-solutions/dynamo",
       "version": "4.0.0-RC3-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^18.2.0",

--- a/dynamo-angular/src/main/dynamo/package.json
+++ b/dynamo-angular/src/main/dynamo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dynamo",
+  "name": "@open-circle-solutions/dynamo",
   "version": "4.0.0-RC3-SNAPSHOT",
   "scripts": {
     "ng": "ng",

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/package.json
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dynamo-angular",
+  "name": "@open-circle-solutions/dynamo-angular",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^18.2.0",

--- a/pom.xml
+++ b/pom.xml
@@ -684,26 +684,27 @@
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>com.ragedunicorn.tools.maven</groupId>
-				<artifactId>github-release-maven-plugin</artifactId>
-				<version>1.0.7</version>
-                        <executions>
-                            <execution>
-                                <id>default-cli</id>
-                                <phase>deploy</phase>
-                                <configuration>
-                                    <owner>opencirclesolutions</owner>
-                                    <repository>dynamo</repository>
-                                    <server>github-oauth</server>
-                                    <tagName>dynamoframework-${project.version}</tagName>
-                                    <name>v${project.version}</name>
-                                    <generateReleaseNotes>true</generateReleaseNotes>
-                                    <body>${project.description}</body>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
+<!--					This is done in a workflow before publishing the release-->
+<!--                    <plugin>-->
+<!--                        <groupId>com.ragedunicorn.tools.maven</groupId>-->
+<!--				<artifactId>github-release-maven-plugin</artifactId>-->
+<!--				<version>1.0.7</version>-->
+<!--                        <executions>-->
+<!--                            <execution>-->
+<!--                                <id>default-cli</id>-->
+<!--                                <phase>deploy</phase>-->
+<!--                                <configuration>-->
+<!--                                    <owner>opencirclesolutions</owner>-->
+<!--                                    <repository>dynamo</repository>-->
+<!--                                    <server>github-oauth</server>-->
+<!--                                    <tagName>dynamoframework-${project.version}</tagName>-->
+<!--                                    <name>v${project.version}</name>-->
+<!--                                    <generateReleaseNotes>true</generateReleaseNotes>-->
+<!--                                    <body>${project.description}</body>-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+<!--                        </executions>-->
+<!--                    </plugin>-->
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Suggested change

- Add workflow `create-release` to set the Dynamo version, create a tag in git and create a draft release in GitHub
- Add workflow `publish-release` to push the jar files to nexus and the angular module to NPMjs

## Still needed setup

The following settings need to be added as action secrets in the GitHub repository:

- `GPG_PRIVATE_KEY`, the GPG key required to sign the Jar files for nexus central.
- `GPG_PASSPHRASE`, the passphrase to be used to access the GPG key.
- `OSS_SONATYPE_USERNAME`, the username to publish to maven central.
- `OSS_SONATYPE_PASSWORD`, the token to be used to publish to maven central.
- `NODE_AUTH_TOKEN`, the authorization token to publish to NPMjs.