### PR TITLE
Angular19 remove bootstrap buttons

### DIFF
--- a/dynamo-angular/src/main/dynamo/package.json
+++ b/dynamo-angular/src/main/dynamo/package.json
@@ -34,6 +34,5 @@
     "@angular/compiler-cli": "^18.2.0",
     "ng-packagr": "^18.2.0",
     "typescript": "~5.5.2"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/dynamo-angular/src/main/dynamo/package.json
+++ b/dynamo-angular/src/main/dynamo/package.json
@@ -34,5 +34,6 @@
     "@angular/compiler-cli": "^18.2.0",
     "ng-packagr": "^18.2.0",
     "typescript": "~5.5.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/blocks/file-upload/file-upload.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/blocks/file-upload/file-upload.component.html
@@ -48,22 +48,21 @@ limitations under the License.
       (uploadHandler)="uploadHandler($event)"
     [auto]="true"></p-fileUpload>
     <!-- Clear button -->
-    <button
+    <p-button
       type="button"
-      class="btn btn-primary mt-1 mr-1"
+      class="mt-1 mr-1"
+      icon="pi pi-ban"
+      label="{{ 'clear' | translate }}"
       (click)="clearUpload()"
-      [disabled]="!getImageContent()">
-      <span class="pi pi-ban"></span> {{ "clear" | translate }}
-    </button>
+      [disabled]="!getImageContent()"/>
     <!-- Download button -->
     @if (getImageContent() && am.downloadAllowed) {
-      <button
+      <p-button
         type="button"
-        class="btn btn-primary mt-1 mr-1"
-        (click)="downloadFile()"
-        >
-        <span class="pi pi-download"></span> {{ "download" | translate }}
-      </button>
+        icon="pi pi-download"
+        label="{{ 'download' | translate }}"
+        class="mt-1 mr-1"
+        (click)="downloadFile()"/>
     }
   </div>
 </div>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/data-table/data-table.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/data-table/data-table.component.html
@@ -122,11 +122,11 @@ let-row>
         target="_blank">{{ getNestedValue(row, col.field) }}</a>
         } <!-- Translate entity --> @if (col.translateEntity) {
         @if (col.navigable && getNestedValue(row,col.field)) {
-          <button
+          <p-button
             type="button"
-            class="btn btn-link"
-            (click)="navigate(row, col)">{{ getNestedValue(row, col.field) | translateEntity :
-          col.translateEntity.property }}</button>
+            link
+            label="{{ getNestedValue(row, col.field) | translateEntity : col.translateEntity.property }}"
+            (click)="navigate(row, col)"/>
           } @if (!col.navigable) {
           {{ getNestedValue(row,col.field) | translateEntity :
           col.translateEntity.property }}
@@ -136,24 +136,22 @@ let-row>
   }
   @if (showDetailButton && detailsModeEnabled) {
     <td>
-      <button
-        type="submit"
-        class="btn btn-primary"
-        pTooltip=" {{ 'to_details_screen' | translate }}"
-        (click)="onDetailButtonClick(row)">
-        <span class="pi pi-pencil"></span>
-      </button>
+        <p-button
+            type="submit"
+            icon="pi pi-pencil"
+            severity="primary"
+            pTooltip="{{ 'to_details_screen' | translate }}"
+            (onClick)="onDetailButtonClick(row)"/>
     </td>
   }
   @if (deleteEnabled) {
     <td>
-      <button
-        type="submit"
-        class="btn btn-danger"
-        pTooltip=" {{ 'delete' | translate }}"
-        (click)="onDeleteClick(row)">
-        <span class="pi pi-trash"></span>
-      </button>
+        <p-button
+          type="button"
+          icon="pi pi-trash"
+          severity="danger"
+          pTooltip="{{ 'delete' | translate }}"
+          (onClick)="onDeleteClick(row)" />
     </td>
   }
   <td><ng-container

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/data-table/data-table.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/data-table/data-table.component.ts
@@ -33,11 +33,12 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ContextMenuModule } from 'primeng/contextmenu';
 import { MultiSelectModule } from 'primeng/multiselect';
 import { FormsModule } from '@angular/forms';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-data-table',
   standalone: true,
-  imports: [TranslateModule, FormsModule, CommonModule, TooltipModule, ContextMenuModule, MultiSelectModule, TableModule, TranslateEntityPipe, TruncatePipe, TranslateEnumPipe, TranslateBooleanPipe],
+  imports: [TranslateModule, FormsModule, CommonModule, TooltipModule, ContextMenuModule, MultiSelectModule, TableModule, TranslateEntityPipe, TruncatePipe, TranslateEnumPipe, TranslateBooleanPipe, Button],
   templateUrl: './data-table.component.html',
   styleUrl: './data-table.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/auto-fill-dialog/auto-fill-dialog.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/auto-fill-dialog/auto-fill-dialog.component.html
@@ -86,19 +86,21 @@ limitations under the License.
   <div
     class="btn-group"
     role="group">
-    <button
+    <p-button
       type="button"
-      class="btn btn-danger m-1"
+      severity="danger"
+      class="m-1"
+      icon="pi pi-times"
+      label="{{ 'cancel' | translate }}"
       (click)="cancel()"
-      [disabled]="loading">
-      <span class="pi pi-times"></span> {{ "cancel" | translate }}
-    </button>
-    <button
+      [disabled]="loading"/>
+    <p-button
       type="button"
-      class="btn btn-success m-1"
+      severity="success"
+      class="m-1"
+      icon="pi pi-check"
+      label="{{ 'ok' | translate }}"
       (click)="execute()"
-      [disabled]="!mainForm?.valid || loading">
-      <span class="pi pi-check"></span> {{ "ok" | translate }}
-    </button>
+      [disabled]="!mainForm?.valid || loading"/>
   </div>
 </p-dialog>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/auto-fill-dialog/auto-fill-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/auto-fill-dialog/auto-fill-dialog.component.ts
@@ -29,11 +29,12 @@ import { AutoFillRequest } from '../../../interfaces/model/autoFillRequest';
 import { MessageModule } from 'primeng/message';
 import { DropdownModule } from 'primeng/dropdown';
 import { DialogModule } from 'primeng/dialog';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-auto-fill-dialog',
   standalone: true,
-  imports: [TranslateModule, ReactiveFormsModule, MessageModule, DropdownModule, DialogModule],
+  imports: [TranslateModule, ReactiveFormsModule, MessageModule, DropdownModule, DialogModule, Button],
   templateUrl: './auto-fill-dialog.component.html',
   styleUrl: './auto-fill-dialog.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/element-collection-dialog/element-collection-dialog.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/element-collection-dialog/element-collection-dialog.component.html
@@ -35,22 +35,17 @@ limitations under the License.
       <div
         class="btn-group"
         role="group">
-        <button
+        <p-button
           id="clearButton"
+          icon="pi pi-times"
           (click)="clear()"
           class="btn btn-danger"
-					[disabled]="
-            (selectedValues && selectedValues.length == 0) || disabled
-          ">
-          <span class="pi pi-times"></span>
-        </button>
-        <button
+            [disabled]="(selectedValues && selectedValues.length == 0) || disabled"/>
+        <p-button
           id="addButton"
+          icon="pi pi-plus"
           [disabled]="disabled"
-          class="btn btn-primary"
-          (click)="showDialog()">
-          <span class="pi pi-plus"></span>
-        </button>
+          (click)="showDialog()"/>
       </div>
     </div>
   </div>
@@ -93,18 +88,20 @@ limitations under the License.
   <div
     class="btn-group"
     role="group">
-    <button
+    <p-button
       type="button"
-      class="btn btn-danger m-1"
-      (click)="cancel()">
-      <span class="pi pi-times"></span> {{ "cancel" | translate }}
-    </button>
-    <button
+      severity="danger"
+      class="m-1"
+      icon="pi pi-times"
+      label="{{ 'cancel' | translate }}"
+      (click)="cancel()"/>
+    <p-button
       type="button"
-      class="btn btn-success m-1"
+      severity="success"
+      class="m-1"
+      icon="pi pi-check"
+      label="{{ 'ok' | translate }}"
       (click)="selectAndClose()"
-      [disabled]="!dialogForm?.valid">
-      <span class="pi pi-check"></span> {{ "ok" | translate }}
-    </button>
+      [disabled]="!dialogForm?.valid"/>
   </div>
 </p-dialog>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/element-collection-dialog/element-collection-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/element-collection-dialog/element-collection-dialog.component.ts
@@ -34,11 +34,12 @@ import { MessageModule } from 'primeng/message';
 import { StringFieldComponent } from '../../forms/fields/string-field/string-field.component';
 import { InputNumberModule } from 'primeng/inputnumber';
 import { DialogModule } from 'primeng/dialog';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-element-collection-dialog',
   standalone: true,
-  imports: [TranslateModule, ReactiveFormsModule, InputNumberModule, DialogModule, MessageModule, StringFieldComponent],
+  imports: [TranslateModule, ReactiveFormsModule, InputNumberModule, DialogModule, MessageModule, StringFieldComponent, Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.html
@@ -17,17 +17,19 @@
     <div
         class="btn-group"
         role="group">
-        <button
+        <p-button
             type="button"
-            class="btn btn-danger m-1"
-            (click)="cancel()">
-            <span class="pi pi-times"></span> {{ "cancel" | translate }}
-        </button>
-        <button
+            severity="danger"
+            label="{{ 'cancel' | translate }}"
+            icon="pi pi-times"
+            class="m-1"
+            (click)="cancel()"/>
+        <p-button
             type="button"
-            class="btn btn-success m-1"
-            (click)="selectAndClose()">
-            <span class="pi pi-check"></span> {{ "ok" | translate }}
-        </button>
+            severity="success"
+            class="m-1"
+            icon="pi pi-check"
+            label="{{ 'ok' | translate }}"
+            (click)="selectAndClose()"/>
     </div>
 </p-dialog>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/entity-search-dialog/entity-search-dialog.component.ts
@@ -27,11 +27,12 @@ import {SelectOption} from "../../../interfaces/select-option";
 import {NG_VALUE_ACCESSOR} from "@angular/forms";
 import LookupQueryTypeEnum = AttributeModelResponse.LookupQueryTypeEnum;
 import {GenericSearchLayoutComponent} from "../../forms/search/generic-search-layout/generic-search-layout.component";
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-entity-search-dialog',
   standalone: true,
-  imports: [DialogModule, TranslateModule, GenericSearchLayoutComponent],
+  imports: [DialogModule, TranslateModule, GenericSearchLayoutComponent, Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/pdf-viewer-dialog/pdf-viewer-dialog.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/pdf-viewer-dialog/pdf-viewer-dialog.component.html
@@ -34,10 +34,11 @@ limitations under the License.
   <div
     class="btn-group"
     role="group">
-    <button
+    <p-button
       type="button"
-      class="btn btn-primary m-1"
-    (click)="closeDialog()">{{ 'close' | translate }}</button>
+      label="{{ 'close' | translate }}"
+      class="m-1"
+      (click)="closeDialog()"/>
   </div>
 </p-dialog>
 }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/pdf-viewer-dialog/pdf-viewer-dialog.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/dialogs/pdf-viewer-dialog/pdf-viewer-dialog.component.ts
@@ -23,11 +23,12 @@ import { NotificationService } from '../../../services/notification.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { PdfViewerComponent } from '../../blocks/pdf-viewer/pdf-viewer.component';
 import { DialogModule } from 'primeng/dialog';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-pdf-viewer-dialog',
   standalone: true,
-  imports: [TranslateModule, PdfViewerComponent, DialogModule],
+  imports: [TranslateModule, PdfViewerComponent, DialogModule, Button],
   templateUrl: './pdf-viewer-dialog.component.html',
   styleUrl: './pdf-viewer-dialog.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/details-grid/details-grid.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/details-grid/details-grid.component.html
@@ -44,13 +44,11 @@ limitations under the License.
             </ng-container></th>
           }
           <th>
-            <button
+            <p-button
               type="button"
-              class="btn btn-primary"
+              icon="pi pi-plus"
               pTooltip=" {{ 'add' | translate }}"
-              (click)="addButtonClick()">
-              <span class="pi pi-plus"></span>
-            </button>
+              (click)="addButtonClick()"/>
           </th>
         </tr>
       </ng-template>
@@ -186,13 +184,12 @@ limitations under the License.
             }</td>
           }
           <td>
-            <button
+            <p-button
               type="button"
-              class="btn btn-danger"
+              severity="danger"
+              icon="pi pi-trash"
               pTooltip=" {{ 'add' | translate}}"
-              (click)="deleteRow(rowIndex)">
-              <span class="pi pi-trash"></span>
-            </button>
+              (click)="deleteRow(rowIndex)"/>
           </td>
         </tr>
       }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/details-grid/details-grid.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/details-grid/details-grid.component.ts
@@ -62,11 +62,12 @@ import { StringFieldComponent } from '../fields/string-field/string-field.compon
 import { FieldViewComponent } from '../field-view/field-view.component';
 import { TableModule } from 'primeng/table';
 import { BaseCompositeComponent } from '../base-composite/base-composite.component';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-details-grid',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslateModule, TableModule, TooltipModule, CheckboxModule, DecimalFieldComponent, NumberFieldComponent, SelectEntityFieldComponent, TimestampFieldComponent, TimeFieldComponent, DateFieldComponent, EnumFieldComponent, StringFieldComponent, FieldViewComponent],
+  imports: [CommonModule, ReactiveFormsModule, TranslateModule, TableModule, TooltipModule, CheckboxModule, DecimalFieldComponent, NumberFieldComponent, SelectEntityFieldComponent, TimestampFieldComponent, TimeFieldComponent, DateFieldComponent, EnumFieldComponent, StringFieldComponent, FieldViewComponent, Button],
   templateUrl: './details-grid.component.html',
   styleUrl: './details-grid.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/field-view/field-view.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/field-view/field-view.component.html
@@ -49,11 +49,11 @@ limitations under the License.
     src="assets/no-preview.png" />
 }
 @if (getNestedValue(entity, am) && am.downloadAllowed) {
-  <button
+  <p-button
     type="button"
-    class="btn btn-primary m-1"
-    (click)="downloadFile(am)"
-  >{{ "download" | translate }}</button>
+    class="m-1"
+    label="{{ 'download' | translate }}"
+    (click)="downloadFile(am)"/>
 }
 </span>
 } <!-- Integral number --> @if (isIntegral(am)) {
@@ -81,10 +81,11 @@ limitations under the License.
 am.falseRepresentations }} </span>
 } @if (isMaster(am)) {
 <span> @if (am.navigable && entity[am.name]) {
-  <button
+  <p-button
     type="button"
-    class="btn btn-link"
-  (click)="navigate(am)">{{ entity[am.name] | translateEntity : am.displayPropertyName! }}</button>
+    link
+    [label]="entity[am.name] | translateEntity : am.displayPropertyName!"
+  (click)="navigate(am)"/>
   } @if (!am.navigable) {
   {{ getNestedValue(entity, am) | translateEntity :
   am.displayPropertyName! }}

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/field-view/field-view.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/field-view/field-view.component.ts
@@ -35,11 +35,12 @@ import { TranslateBooleanPipe } from '../../../pipes/translate-boolean.pipe';
 import { TranslateEnumPipe } from '../../../pipes/translate-enum.pipe';
 import { CommonModule } from '@angular/common';
 import { FieldViewTableComponent } from '../field-view-table/field-view-table.component';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-field-view',
   standalone: true,
-  imports: [CommonModule, TranslateModule, TranslateEntityPipe, TranslateBooleanPipe, TranslateEnumPipe, FieldViewTableComponent],
+  imports: [CommonModule, TranslateModule, TranslateEntityPipe, TranslateBooleanPipe, TranslateEnumPipe, FieldViewTableComponent, Button],
   templateUrl: './field-view.component.html',
   styleUrl: './field-view.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.html
@@ -36,31 +36,25 @@ limitations under the License.
             <div
                 class="btn-group"
                 role="group">
-                <button
+                <p-button
                     type="button"
-                    class="btn btn-danger"
+                    severity="danger"
+                    icon="pi pi-times"
                     (click)="clear()"
-                    [disabled]="selectedValues.length == 0 || disabled">
-                    <span class="pi pi-times"></span>
-                </button>
-                <button
-                    class="btn btn-primary"
+                    [disabled]="selectedValues.length == 0 || disabled"/>
+                <p-button
                     type="button"
+                    icon="pi pi-search"
                     (click)="showDialog()"
-                    [disabled]="disabled">
-                    <span class="pi pi-search"></span>
-                </button>
+                    [disabled]="disabled"/>
                 <ng-template #searchDialogContainerRef></ng-template>
 
                 @if (isQuickAddButtonVisible()) {
-                    <button
-                        class="btn btn-primary"
+                    <p-button
                         type="button"
+                        icon="pi pi-plus"
                         (click)="showQuickAddDialog()"
-                        [disabled]="disabled"
-                    >
-                        <span class="pi pi-plus"></span>
-                    </button>
+                        [disabled]="disabled"/>
                 }
                 <ng-template #popupDialogContainerRef></ng-template>
             </div>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/lookup-field/lookup-field.component.ts
@@ -30,11 +30,12 @@ import {EntityPopupDialogComponent} from '../../../dialogs/entity-popup-dialog/e
 import {truncateDescriptions} from '../../../../functions/entitymodel-functions';
 import {DialogModule} from 'primeng/dialog';
 import {EntitySearchDialogComponent} from "../../../dialogs/entity-search-dialog/entity-search-dialog.component";
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-lookup-field',
   standalone: true,
-  imports: [TranslateModule, DialogModule],
+  imports: [TranslateModule, DialogModule, Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-entity-field/select-entity-field.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-entity-field/select-entity-field.component.html
@@ -39,13 +39,10 @@ limitations under the License.
         </div>
         <div class="col-2">
           @if (isQuickAddButtonVisible() && useComboField(am)) {
-            <button
-              class="btn btn-primary"
+            <p-button
               type="button"
-              (click)="showQuickAddDialog()"
-              >
-              <span class="pi pi-plus"></span>
-            </button>
+              icon="pi pi-plus"
+              (click)="showQuickAddDialog()"/>
           }
         </div>
       </div>
@@ -84,13 +81,10 @@ limitations under the License.
         </div>
         <div class="col-1">
           @if (isQuickAddButtonVisible() && useAutocompleteField(am)) {
-            <button
-              class="btn btn-primary"
+            <p-button
               type="button"
-              (click)="showQuickAddDialog()"
-              >
-              <span class="pi pi-plus"></span>
-            </button>
+              icon="pi pi-plus"
+              (click)="showQuickAddDialog()"/>
           }
         </div>
       </div>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-entity-field/select-entity-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-entity-field/select-entity-field.component.ts
@@ -39,11 +39,12 @@ import {LookupFieldComponent} from '../lookup-field/lookup-field.component';
 import {MultiSelectModule} from 'primeng/multiselect';
 import {DropdownModule} from 'primeng/dropdown';
 import {EntityPopupDialogComponent} from "../../../dialogs/entity-popup-dialog/entity-popup-dialog.component";
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-select-entity-field',
   standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, MessageModule, DropdownModule, MultiSelectModule, AutoCompleteModule, TooltipModule, forwardRef(() => LookupFieldComponent), ReactiveFormsModule],
+  imports: [ReactiveFormsModule, CommonModule, MessageModule, DropdownModule, MultiSelectModule, AutoCompleteModule, TooltipModule, forwardRef(() => LookupFieldComponent), ReactiveFormsModule, Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-many-field/select-many-field.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-many-field/select-many-field.component.html
@@ -38,13 +38,10 @@ limitations under the License.
         </div>
         <div class="col-2">
           @if (isQuickAddButtonVisible() && !useLookupField(am)) {
-            <button
-              class="btn btn-primary"
+            <p-button
               type="button"
-              (click)="showQuickAddDialog()"
-              >
-              <span class="pi pi-plus"></span>
-            </button>
+              icon="pi pi-plus"
+              (click)="showQuickAddDialog()"/>
           }
         </div>
       </div>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-many-field/select-many-field.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/fields/select-many-field/select-many-field.component.ts
@@ -30,6 +30,7 @@ import {LookupFieldComponent} from '../lookup-field/lookup-field.component';
 import {NG_VALUE_ACCESSOR, ReactiveFormsModule} from '@angular/forms';
 import {MultiSelectModule} from 'primeng/multiselect';
 import {EntityPopupDialogComponent} from "../../../dialogs/entity-popup-dialog/entity-popup-dialog.component";
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-select-many-field',
@@ -41,7 +42,7 @@ import {EntityPopupDialogComponent} from "../../../dialogs/entity-popup-dialog/e
       multi: true,
     },
   ],
-  imports: [MessageModule, TooltipModule, ReactiveFormsModule, MultiSelectModule, forwardRef(() => LookupFieldComponent), ReactiveFormsModule],
+  imports: [MessageModule, TooltipModule, ReactiveFormsModule, MultiSelectModule, forwardRef(() => LookupFieldComponent), ReactiveFormsModule, Button],
   templateUrl: './select-many-field.component.html',
   styleUrl: './select-many-field.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.html
@@ -57,49 +57,46 @@
                         class="btn-group"
                         role="group"
                         *ngIf="entityModel">
-                    <button
+                    <p-button
                             type="button"
-                            class="btn btn-primary m-1"
+                            class="m-1"
+                            icon="pi pi-arrow-left"
+                            label="{{ 'back' | translate }}"
                             (click)="back()"
-                            *ngIf="backEnabled()">
-                        <span class="pi pi-arrow-left"></span> {{ "back" | translate }}
-                    </button>
-                    <button
+                            *ngIf="backEnabled()" />
+                    <p-button
                             type="button"
                             *ngIf="nested"
-                            class="btn btn-danger m-1"
-                            (click)="closeDialog()">
-                        <span class="pi pi-times"></span> {{ "close" | translate }}
-                    </button>
-                    <button
+                            class="m-1"
+                            severity="danger"
+                            icon="pi pi-times"
+                            label="{{ 'close' | translate }}"
+                            (click)="closeDialog()"/>
+                    <p-button
                             type="button"
-                            class="btn btn-primary m-1"
+                            class="m-1"
+                            icon="pi pi-pencil"
+                            label="{{ 'edit' | translate }}"
                             (click)="editMode()"
-                            *ngIf="
-          entityModel.updateAllowed && this.isWriteAllowed() && !this.readOnly">
-                        <span class="pi pi-pencil"></span> {{ "edit" | translate }}
-                    </button>
+                            *ngIf="entityModel.updateAllowed && this.isWriteAllowed() && !this.readOnly"/>
                     @for (action of filterEntityModelActions(); track action) {
-                        <button
+                        <p-button
                                 type="button"
-                                class="btn btn-primary m-1"
+                                class="m-1"
+                                icon="pi {{ action.icon }}"
+                                label="{{ action.displayNames[locale] }}"
                                 [disabled]="loading || !isModelActionEnabled(action)"
-                                (click)="callModelAction(vcr, action)">
-                            <span class="pi {{ action.icon }}"></span> {{ action.displayNames[locale] }}
-                        </button>
+                                (click)="callModelAction(vcr, action)"/>
                     }
                     @for (action of filterAdditionalActions(); track action) {
-                        <button
+                        <p-button
                                 type="submit"
-                                class="btn btn-primary m-1"
+                                class="m-1"
+                                icon="{{ action.icon ? 'pi ' + action.icon : ''}}"
+                                label="{{ action.messageKey | translate }}"
                                 (click)="callAdditionalAction(action)"
                                 [class]="action.buttonClass"
-                                [disabled]="loading || isAdditionalFormActionDisabled(action)">
-                            @if (action.icon) {
-                                <span class="pi {{ action.icon }}"></span>
-                            }
-                            {{ action.messageKey | translate }}
-                        </button>
+                                [disabled]="loading || isAdditionalFormActionDisabled(action)"/>
                     }
                     <ng-template #popupDialogContainerRef></ng-template>
                 </div>
@@ -176,56 +173,58 @@
                             class="btn-group"
                             role="group">
                         <!-- Navigate back button -->
-                        <button
+                        <p-button
                                 type="button"
-                                class="btn btn-primary m-1"
+                                class="m-1"
+                                icon="pi pi-arrow-left"
+                                label="{{ 'back' | translate }}"
                                 (click)="back()"
                                 *ngIf="backEnabled()"
-                                [disabled]="loading">
-                            <span class="pi pi-arrow-left"></span> {{ "back" | translate }}
-                        </button>
+                                [disabled]="loading"/>
                         <!-- Cancel -->
-                        <button
+                        <p-button
                                 type="submit"
-                                class="btn btn-primary m-1"
+                                class="m-1"
+                                icon="pi pi-ban"
+                                label="{{ 'cancel' | translate }}"
                                 [disabled]="loading"
                                 (click)="cancelEdit()"
-                                *ngIf="!nested && openInViewMode && entityId">
-                            <span class="pi pi-ban"></span> {{ "cancel" | translate }}
-                        </button>
+                                *ngIf="!nested && openInViewMode && entityId"/>
                         <!-- Save button -->
-                        <button
+                        <p-button
                                 type="submit"
-                                class="btn btn-primary m-1"
+                                class="m-1"
+                                icon="pi pi-save"
+                                label="{{ 'save' | translate }}"
                                 [disabled]="loading || isFormDisabled()"
-                                (click)="save()">
-                            <span class="pi pi-save"></span> {{ "save" | translate }}
-                        </button>
-                        <button
+                                (click)="save()"/>
+                        <p-button
                                 *ngFor="let action of filterEntityModelActions()"
                                 type="button"
-                                class="btn btn-primary m-1"
+                                class="m-1"
+                                icon="pi {{ action.icon }}"
+                                label="{{ action.displayNames[locale] }}"
                                 [disabled]="!isModelActionEnabled(action)"
-                                (click)="callModelAction(vcr, action)">
-                            <span class="pi {{ action.icon }}"></span> {{ action.displayNames[locale] }}
-                        </button>
+                                (click)="callModelAction(vcr, action)"/>
                         <ng-template #popupDialogContainerRef></ng-template>
-                        <button
+                        <p-button
                                 type="button"
                                 *ngIf="formFillEnabled && !nested"
-                                class="btn btn-primary m-1"
-                                (click)="showFormFillDialog()">
-                            <span class="pi pi-filter-fill"></span> {{ "ai_fill" | translate }}
-                        </button>
+                                class="m-1"
+                                icon="pi pi-filter-fill"
+                                label="{{ 'ai_fill' | translate }}"
+                                (click)="showFormFillDialog()"/>
                         <ng-template #formFillContainerRef></ng-template>
                         <!-- Close button (only visible when nested inside popup)-->
-                        <button
+                        <p-button
                                 type="button"
                                 *ngIf="nested"
-                                class="btn btn-danger m-1"
-                                (click)="closeDialog()">
-                            <span class="pi pi-times"></span> {{ "close" | translate }}
-                        </button>
+                                severity="danger"
+                                icon="pi pi-times"
+                                label="{{ 'close' | translate }}"
+                                [disabled]="loading"
+                                class="m-1"
+                                (click)="closeDialog()"/>
                         <!-- Extra UI actions-->
                         @for (action of filterAdditionalActions(); track action) {
                             <ng-container [ngTemplateOutlet]="customActionTemplate"
@@ -241,16 +240,14 @@
         <ng-template
             #customActionTemplate
             let-action>
-            <button
+            <p-button
                     type="submit"
-                    class="btn btn-primary m-1"
+                    class="m-1"
+                    icon="{{ action.icon ? 'pi ' + action.icon : ''}}"
+                    label="{{ action.messageKey | translate }}"
                     (click)="callAdditionalAction(action)"
                     [class]="action.buttonClass"
-                    [disabled]="loading || isAdditionalFormActionDisabled(action)">
-	<span
-            *ngIf="action.icon"
-            class="pi {{ action.icon }}"></span> {{ action.messageKey | translate }}
-            </button>
+                    [disabled]="loading || isAdditionalFormActionDisabled(action)"/>
         </ng-template> <!-- template for showing a single form field -->
         <ng-template
             #formTemplate

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/generic-form/generic-form.component.ts
@@ -86,11 +86,12 @@ import { GenericFormViewComponent } from '../generic-form-view/generic-form-view
 import { DividerModule } from 'primeng/divider';
 import { GenericFieldComponent } from '../fields/generic-field/generic-field.component';
 import { BaseCompositeComponent } from '../base-composite/base-composite.component';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-generic-form',
   standalone: true,
-  imports: [TranslateModule, CommonModule, TabViewModule, PanelModule, DividerModule, ReactiveFormsModule, GenericFieldComponent, FileUploadComponent, DetailsGridComponent, FieldViewComponent, GenericFormViewComponent],
+  imports: [TranslateModule, CommonModule, TabViewModule, PanelModule, DividerModule, ReactiveFormsModule, GenericFieldComponent, FileUploadComponent, DetailsGridComponent, FieldViewComponent, GenericFormViewComponent, Button],
   templateUrl: './generic-form.component.html',
   styleUrl: './generic-form.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/flexible-search-form/flexible-search-form.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/flexible-search-form/flexible-search-form.component.html
@@ -30,14 +30,14 @@ limitations under the License.
           class="row"
           >
           <div class="col-1">
-            <button
+            <p-button
               type="button"
-              class="btn btn-danger m-1"
+              severity="danger"
+              class="m-1"
+              icon="pi pi-trash"
               [disabled]="loading || row.required"
               pTooltip=" {{ 'delete' | translate }}"
-              (click)="deleteRow(i)">
-              <span class="pi pi-trash"></span>
-            </button>
+              (click)="deleteRow(i)"/>
           </div>
           <!-- Dropdown for selecting attribute to search on -->
           <div class="col-4">
@@ -76,27 +76,27 @@ limitations under the License.
     <div
       class="btn-group mt-2"
       role="group">
-      <button
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
+        class="m-1"
+        icon="pi pi-plus"
+        label="{{ 'add_filter' | translate }}"
         [disabled]="loading"
-        (click)="addRow(false)">
-        <span class="pi pi-plus"></span> {{ "add_filter" | translate }}
-      </button>
-      <button
+        (click)="addRow(false)"/>
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
+        class="m-1"
+        icon="pi pi-plus"
+        label="{{ 'search' | translate }}"
         [disabled]="loading"
-        (click)="search()">
-        <span class="pi pi-search"></span> {{ "search" | translate }}
-      </button>
-      <button
+        (click)="search()"/>
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
+        class="m-1"
+        icon="pi pi-eraser"
+        label="{{ 'clear' | translate }}"
         [disabled]="loading"
-        (click)="clear()">
-        <span class="pi pi-eraser"></span> {{ "clear" | translate }}
-      </button>
+        (click)="clear()"/>
     </div>
   </form>
 }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/flexible-search-form/flexible-search-form.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/flexible-search-form/flexible-search-form.component.ts
@@ -51,6 +51,7 @@ import { StringFieldComponent } from '../../fields/string-field/string-field.com
 import { CommonModule } from '@angular/common';
 import { DropdownModule } from 'primeng/dropdown';
 import { PanelModule } from 'primeng/panel';
+import {Button} from "primeng/button";
 
 export interface SearchRow {
   index: number
@@ -64,7 +65,7 @@ export interface SearchRow {
   selector: 'd-flexible-search-form',
   standalone: true,
   imports: [TranslateModule, CommonModule, ReactiveFormsModule, PanelModule, DropdownModule, TooltipModule, TriStateCheckboxModule, StringFieldComponent, forwardRef(() => SelectManyFieldComponent),
-    forwardRef(() => SelectEntityFieldComponent), EnumFieldComponent, TimeFieldComponent, DecimalFieldComponent, DateFieldComponent, TimestampFieldComponent, NumberFieldComponent, ElementCollectionFieldComponent],
+    forwardRef(() => SelectEntityFieldComponent), EnumFieldComponent, TimeFieldComponent, DecimalFieldComponent, DateFieldComponent, TimestampFieldComponent, NumberFieldComponent, ElementCollectionFieldComponent, Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-form/generic-search-form.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-form/generic-search-form.component.html
@@ -40,39 +40,41 @@ limitations under the License.
       </div>
     </p-panel>
     <div
-      class="btn-group mt-2"
+      class="mt-2 btn-group"
       role="group">
-      <button
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
+        severity="primary"
+        class="m-1"
+        icon="pi pi-search"
+        label="{{ 'search' | translate }}"
         [disabled]="loading"
-        (click)="search()">
-        <span class="pi pi-search"></span> {{ "search" | translate }}
-      </button>
-      <button
+        (click)="search()"/>
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
+        severity="primary"
+        class="m-1"
+        icon="pi pi-eraser"
+        label="{{ 'clear' | translate }}"
         [disabled]="loading"
-        (click)="clear()">
-        <span class="pi pi-eraser"></span> {{ "clear" | translate }}
-      </button>
+        (click)="clear()"/>
       @if (!advancedMode && advancedModeEnabled) {
-        <button
+        <p-button
           type="button"
-          class="btn btn-primary m-1"
+          class="m-1"
+          severity="primary"
+          icon="pi pi-search-plus"
+          label="{{ 'advanced_mode' | translate }}"
           (click)="toAdvancedMode()"
-          [disabled]="loading">
-          <span class="pi pi-search-plus"></span> {{ "advanced_mode" | translate }}
-        </button>
+          [disabled]="loading"/>
       }
       @if (advancedMode && advancedModeEnabled) {
-        <button
+        <p-button
           type="button"
-          class="btn btn-primary m-1"
-          (click)="toSimpleMode()"
-          >
-          <span class="pi pi-search-minus"></span> {{ "simple_mode" | translate }}
-        </button>
+          class="m-1"
+          icon="pi pi-search-minus"
+          label="{{ 'simple_mode' | translate }}"
+          (click)="toSimpleMode()"/>
       }
     </div>
     <ng-template

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-form/generic-search-form.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-form/generic-search-form.component.ts
@@ -45,12 +45,13 @@ import { NumberFieldComponent } from '../../fields/number-field/number-field.com
 import { StringFieldComponent } from '../../fields/string-field/string-field.component';
 import { CommonModule } from '@angular/common';
 import { PanelModule } from 'primeng/panel';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-generic-search-form',
   standalone: true,
   imports: [TranslateModule, CommonModule, ReactiveFormsModule, PanelModule, TriStateCheckboxModule, TooltipModule, ElementCollectionFieldComponent, forwardRef(() => SelectManyFieldComponent),
-    forwardRef(() => SelectEntityFieldComponent), TimeFieldComponent, TimestampFieldComponent, DateFieldComponent, EnumFieldComponent, DecimalFieldComponent, NumberFieldComponent, StringFieldComponent],
+    forwardRef(() => SelectEntityFieldComponent), TimeFieldComponent, TimestampFieldComponent, DateFieldComponent, EnumFieldComponent, DecimalFieldComponent, NumberFieldComponent, StringFieldComponent, Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-layout/generic-search-layout.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-layout/generic-search-layout.component.html
@@ -89,36 +89,34 @@ limitations under the License.
           role="group"
           >
           @if (entityModel?.createAllowed! && isWriteAllowed()) {
-            <button
+            <p-button
               type="button"
-              class="btn btn-primary m-1"
+              class="m-1"
+              icon="pi pi-plus"
+              label="{{ 'add' | translate }}"
               (click)="add()"
-              [disabled]="loading">
-              <span class="pi pi-plus"></span> {{ "add" | translate }}
-            </button>
+              [disabled]="loading"/>
           }
           <!-- Server defined actions-->
           @for (action of filterEntityModelActions(); track action) {
-            <button
+            <p-button
               type="button"
-              class="btn btn-primary m-1"
+              class="m-1"
+              icon="pi {{ action.icon }}"
+              label="{{ action.displayNames[locale] }}"
               (click)="callModelAction(vcr, action, undefined)"
-              [disabled]="loading || !isModelActionEnabled({}, action)">
-              <span class="pi {{ action.icon }}"></span> {{ action.displayNames[locale] }}
-            </button>
+              [disabled]="loading || !isModelActionEnabled({}, action)"/>
           }
           <!-- UI defined global actions -->
           @for (action of additionalGlobalActions; track action) {
-            <button
+            <p-button
               type="button"
-              [class]="action.buttonClass"
+              icon="{{ action.icon ? 'pi ' + action.icon : '' }}"
+              label="{{ action.messageKey | translate }}"
+              class="m-1"
+              [severity]="action.buttonClass"
               (click)="callAdditionalGlobalAction(action)"
-              [disabled]="loading || isGlobalActionDisabled(action)">
-              @if (action.icon) {
-                <span
-                class="pi {{ action.icon }}"></span>
-                } {{ action.messageKey | translate }}
-              </button>
+              [disabled]="loading || isGlobalActionDisabled(action)"/>
             }
           </div>
         }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-layout/generic-search-layout.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/forms/search/generic-search-layout/generic-search-layout.component.ts
@@ -32,11 +32,12 @@ import { FlexibleSearchFormComponent } from '../flexible-search-form/flexible-se
 import { BaseCompositeCollectionComponent } from '../../base-composite-collection/base-composite-collection.component';
 import { GenericSearchFormComponent } from '../generic-search-form/generic-search-form.component';
 import {NG_VALUE_ACCESSOR} from "@angular/forms";
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-generic-search-layout',
   standalone: true,
-  imports: [TranslateModule, DividerModule, GenericTableComponent, forwardRef(() => FlexibleSearchFormComponent), forwardRef(() => GenericSearchFormComponent)],
+  imports: [TranslateModule, DividerModule, GenericTableComponent, forwardRef(() => FlexibleSearchFormComponent), forwardRef(() => GenericSearchFormComponent), Button],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-edit-table-layout/generic-edit-table-layout.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-edit-table-layout/generic-edit-table-layout.component.html
@@ -44,38 +44,32 @@ limitations under the License.
     [modelActionEnabled]="modelActionEnabled"
     (onSearchComplete)="searchComplete()"></d-generic-table> <ng-template #popupDialogContainerRef></ng-template> <!-- Dialog to add new entity-->
     <div
-      class="btn-group"
+      class="btn-group m-1"
       role="group">
       @if (entityModel?.createAllowed! && isWriteAllowed()) {
-        <button
-          type="button"
-          class="btn btn-primary m-1"
+        <p-button
+          icon="pi pi-plus"
+          label="{{ 'add' | translate }}"
           (click)="openNewEntityDialog()"
-          [disabled]="loading">
-          <span class="pi pi-plus"></span> {{ "add" | translate }}
-        </button>
+          [disabled]="loading" />
       }
       <!-- Server defined actions-->
       @for (action of filterEntityModelActions(); track action) {
-        <button
+        <p-button
           type="button"
-          class="btn btn-primary m-1"
-          (click)="callModelAction(vcr, action, undefined)">
-          <span class="pi {{ action.icon }}"></span> {{ action.displayNames[locale] }}
-        </button>
+          icon="pi {{ action.icon }}"
+          label="{{ action.displayNames[locale] }}"
+          (click)="callModelAction(vcr, action, undefined)" />
       }
       <!-- UI defined global actions -->
       @for (action of additionalGlobalActions; track action) {
-        <button
+        <p-button
           type="button"
+          icon="{{ action.icon ? 'pi ' + action.icon : '' }}"
+          label="{{ action.messageKey | translate }}"
           [class]="action.buttonClass"
           (click)="callAdditionalGlobalAction(action)"
-          [disabled]="loading || isGlobalActionDisabled(action)">
-          @if (action.icon) {
-            <span
-            class="pi {{ action.icon }}"></span>
-            } {{ action.messageKey | translate }}
-          </button>
+          [disabled]="loading || isGlobalActionDisabled(action)"/>
         }
       </div>
     }

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-edit-table-layout/generic-edit-table-layout.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-edit-table-layout/generic-edit-table-layout.component.ts
@@ -30,11 +30,12 @@ import { HiddenFieldService } from '../../services/hidden-field.service';
 import { EntityPopupDialogComponent } from '../dialogs/entity-popup-dialog/entity-popup-dialog.component';
 import { AttributeModelResponse } from '../../interfaces/model/attributeModelResponse';
 import { TranslateModule } from '@ngx-translate/core';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-generic-edit-table-layout',
   standalone: true,
-  imports: [TranslateModule, GenericTableComponent],
+  imports: [TranslateModule, GenericTableComponent, Button],
   providers: [HiddenFieldService],
   templateUrl: './generic-edit-table-layout.component.html',
   styleUrl: './generic-edit-table-layout.component.css'

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-split-layout/generic-split-layout.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-split-layout/generic-split-layout.component.html
@@ -39,18 +39,20 @@ limitations under the License.
   <div
     class="btn-group"
     role="group">
-    <button
+    <p-button
       type="button"
-      class="btn btn-danger m-1"
-      (click)="cancelDialog()">
-      <span class="pi pi-times"></span> {{ "cancel" | translate }}
-    </button>
-    <button
+      severity="danger"
+      class="m-1"
+      icon="pi pi-times"
+      label="{{ 'cancel' | translate }}"
+      (click)="cancelDialog()"/>
+    <p-button
       type="button"
-      class="btn btn-success m-1"
-      (click)="selectAndClose()">
-      <span class="pi pi-check"></span> {{ "ok" | translate }}
-    </button>
+      severity="success"
+      icon="pi pi-check"
+      label="{{ 'ok' | translate }}"
+      class="m-1"
+      (click)="selectAndClose()"/>
   </div>
 </p-dialog> <p-splitter> <ng-template pTemplate>
 <div class="col-lg-12 col-md-12 p-3">
@@ -76,29 +78,27 @@ limitations under the License.
       <div class="col">
         @if (searchDialogEnabled) {
           <div
-            class="btn-group"
-            role="group"
-            class="mb-2"
-            >
+            class="btn-group mb-2"
+            role="group">
             @if (searchDialogEnabled) {
-              <button
+              <p-button
                 id="openSearchDialogButton"
                 type="button"
-                class="btn btn-primary m-1"
-                (click)="openSearchDialog()"
-                >
-                <span class="pi pi-search"></span> {{ "search" | translate }}
-              </button>
+                severity="primary"
+                icon="pi pi-search"
+                label="{{ 'search' | translate }}"
+                class="m-1"
+                (click)="openSearchDialog()"/>
             }
             @if (searchDialogEnabled) {
-              <button
+              <p-button
                 id="clearSearchFilterButton"
                 type="button"
-                class="btn btn-primary m-1"
-                (click)="clearSearchFilter()"
-                >
-                <span class="pi pi-eraser"></span> {{ "clear" | translate }}
-              </button>
+                severity="primary"
+                class="m-1"
+                icon="pi pi-times"
+                label="{{ 'clear' | translate }}"
+                (click)="clearSearchFilter()"/>
             }
           </div>
         }
@@ -124,35 +124,33 @@ limitations under the License.
     class="btn-group"
     role="group">
     @if (entityModel?.createAllowed! && isWriteAllowed()) {
-      <button
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
+        severity="primary"
+        class="m-1"
         (click)="add()"
-        >
-        <span class="pi pi-plus"></span> {{ "add" | translate }}
-      </button>
+        icon="pi pi-plus"
+        label="{{ 'add' | translate }}"/>
     }
     <!-- Server defined actions-->
     @for (action of filterEntityModelActions(); track action) {
-      <button
+      <p-button
         type="button"
-        class="btn btn-primary m-1"
-        (click)="callModelAction(vcr, action, undefined)">
-        <span class="pi {{ action.icon }}"></span> {{ action.displayNames[locale] }}
-      </button>
+        severity="primary"
+        class="m-1"
+        icon="pi {{ action.icon }}"
+        label="{{ action.displayNames[locale] }}"
+        (click)="callModelAction(vcr, action, undefined)"/>
     }
     <!-- UI defined global actions -->
     @for (action of additionalGlobalActions; track action) {
-      <button
+      <p-button
         type="button"
-        [class]="action.buttonClass"
+        [severity]="action.buttonClass"
+        icon="{{ action.icon ? 'pi ' + action.icon : '' }}"
+        label="{{ action.messageKey | translate }}"
         (click)="callAdditionalGlobalAction(action)"
-        [disabled]="isGlobalActionDisabled(action)">
-        @if (action.icon) {
-          <span
-          class="pi {{ action.icon }}"></span>
-          } {{ action.messageKey | translate }}
-        </button>
+        [disabled]="isGlobalActionDisabled(action)" />
       }
       <ng-template #popupDialogContainerRef></ng-template>
     </div>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-split-layout/generic-split-layout.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-split-layout/generic-split-layout.component.ts
@@ -32,11 +32,12 @@ import { AuthenticationService } from '../../services/authentication.service';
 import { HiddenFieldService } from '../../services/hidden-field.service';
 import { DynamoConfig } from '../../interfaces/dynamo-config';
 import { FormInfo } from '../../interfaces/info';
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'd-generic-split-layout',
   standalone: true,
-  imports: [TranslateModule, GenericTableComponent],
+  imports: [TranslateModule, GenericTableComponent, Button],
   templateUrl: './generic-split-layout.component.html',
   styleUrl: './generic-split-layout.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-table/generic-table.component.html
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-table/generic-table.component.html
@@ -43,38 +43,27 @@ limitations under the License.
       class="btn-group"
       role="group">
       @if (showPopupButton()) {
-        <button
-          type="button"
-          pTooltip=" {{ 'details' | translate}}"
-          class="btn btn-primary m-1"
-          (click)="openEntityDialog(row)">
-          <span class="pi pi-eye"></span>
-        </button>
+          <p-button type="button"
+                    pTooltip=" {{ 'details' | translate}}"
+                    icon="pi pi-eye"
+                    (click)="openEntityDialog(row)" />
       }
       <!-- Additional entity model actions -->
       @for (action of filterEntityModelActions(); track action) {
-        <button
-          type="button"
-          class="btn btn-primary m-1"
-          [disabled]="!isModelActionEnabled(row, action) || loading"
-          (click)="callModelAction(vcr, action, row)"
-          pTooltip="{{ action.displayNames[locale] }}">
-          <span class="pi {{ action.icon }}"></span>
-        </button>
+          <p-button type="button"
+                    severity="primary"
+                    [disabled]="!isModelActionEnabled(row, action) || loading"
+                    (click)="callModelAction(vcr, action, row)"
+                    icon="pi {{ action.icon }}"
+                    pTooltip="{{ action.displayNames[locale] }}" />
       }
       <!-- Additional UI defined actions -->
       @for (action of additionalRowActions; track action) {
-        <button
-          type="button"
-          [class]="action.buttonClass"
-          (click)="callAdditionalRowAction(action, row)"
-          pTooltip="{{ action.messageKey | translate }}"
-          [disabled]="isRowActionDisabled(action, row) || loading">
-          @if (action.icon) {
-            <span
-            class="pi {{ action.icon }}"></span>
-          }
-        </button>
+          <p-button [class]="action.buttonClass"
+                    icon="{{ action.icon ? 'pi ' + action.icon : '' }}"
+                    (click)="callAdditionalRowAction(action, row)"
+                    pTooltip="{{ action.messageKey | translate }}"
+                    [disabled]="isRowActionDisabled(action, row) || loading"/>
       }
       <ng-template #popupDialogContainerRef></ng-template>
     </div>

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-table/generic-table.component.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/components/generic-table/generic-table.component.ts
@@ -43,11 +43,13 @@ import { AdditionalRowAction } from '../../interfaces/action';
 import { DataTableComponent, TableColumn } from '../data-table/data-table.component';
 import { BaseCompositeCollectionComponent } from '../forms/base-composite-collection/base-composite-collection.component';
 import { TooltipModule } from 'primeng/tooltip';
+import {Button} from "primeng/button";
+import {ButtonGroup, ButtonGroupModule} from "primeng/buttongroup";
 
 @Component({
   selector: 'd-generic-table',
   standalone: true,
-  imports: [TranslateModule, TooltipModule, DataTableComponent],
+  imports: [TranslateModule, TooltipModule, DataTableComponent, Button],
   templateUrl: './generic-table.component.html',
   styleUrl: './generic-table.component.css'
 })

--- a/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/interfaces/action.ts
+++ b/dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/interfaces/action.ts
@@ -25,7 +25,7 @@ export enum AdditionalActionMode {
 export interface AdditionalActionBase {
   icon?: string;
   messageKey: string;
-  buttonClass?: string;
+  buttonClass?: "info" | "success" | "warning" | "danger" | "secondary" | "contrast" | "help" | "primary";
 }
 
 /**


### PR DESCRIPTION
## Suggested change
Replacing all bootstrap buttons for PrimeNG once. This will help to slowly remove bootstrap all together from the project as PrimeNG is the chosen UI library.

## Breaking change
This change does limit the `buttonClass` to accept only the `severity` types of PrimeNG buttons. See `dynamo-angular/src/main/dynamo/projects/dynamo-angular/src/lib/interfaces/action.ts` for the impacted configuration.